### PR TITLE
CORS 문제 해결

### DIFF
--- a/AI_Image_EXIF_Viewer.user.js
+++ b/AI_Image_EXIF_Viewer.user.js
@@ -211,6 +211,23 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
                         });
                     }
                 });
+                GM_registerMenuCommand('아카라이브 EXIF 보존 토글', () => {
+                    if (GM_getValue('saveExifDefault', true)) {
+                        GM_setValue('saveExifDefault', false);
+                        toastmix.fire({
+                            icon: 'error',
+                            title: `아카라이브 EXIF 보존 비활성화
+                      다음번 작성시부터 버려집니다`,
+                        });
+                    } else {
+                        GM_setValue('saveExifDefault', true);
+                        toastmix.fire({
+                            icon: 'success',
+                            title: `아카라이브 EXIF 보존 활성화
+                      다음번 작성시부터 보존됩니다`,
+                        });
+                    }
+                });
                 // https://arca.live/b/aiart/121872652 ::::: 수정 250211
                 // todo: 일단 주석처리해보고 문제 없으면 그대로 두기
                 // GM_registerMenuCommand('아카라이브 글쓰기 창 스크립트 토글', () => {
@@ -230,23 +247,6 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
                 //         });
                 //     }
                 // });
-                GM_registerMenuCommand('아카라이브 글쓰기 창 스크립트 토글', () => {
-                    if (GM_getValue('useDragdropUpload', true)) {
-                        GM_setValue('useDragdropUpload', false);
-                        toastmix.fire({
-                            icon: 'error',
-                            title: `아카 글쓰기 창 스크립트 비활성화
-                      다음번 작성시부터 적용됩니다`,
-                        });
-                    } else {
-                        GM_setValue('useDragdropUpload', true);
-                        toastmix.fire({
-                            icon: 'success',
-                            title: `아카 글쓰기 창 스크립트 활성화
-                      다음번 작성시부터 적용됩니다`,
-                        });
-                    }
-                });
             }
         } catch (err) {
             console.log(err);

--- a/AI_Image_EXIF_Viewer.user.js
+++ b/AI_Image_EXIF_Viewer.user.js
@@ -228,25 +228,23 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
                         });
                     }
                 });
-                // https://arca.live/b/aiart/121872652 ::::: 수정 250211
-                // todo: 일단 주석처리해보고 문제 없으면 그대로 두기
-                // GM_registerMenuCommand('아카라이브 글쓰기 창 스크립트 토글', () => {
-                //     if (GM_getValue('useDragdropUpload', true)) {
-                //         GM_setValue('useDragdropUpload', false);
-                //         toastmix.fire({
-                //             icon: 'error',
-                //             title: `아카 글쓰기 창 스크립트 비활성화
-                //       다음번 작성시부터 적용됩니다`,
-                //         });
-                //     } else {
-                //         GM_setValue('useDragdropUpload', true);
-                //         toastmix.fire({
-                //             icon: 'success',
-                //             title: `아카 글쓰기 창 스크립트 활성화
-                //       다음번 작성시부터 적용됩니다`,
-                //         });
-                //     }
-                // });
+                GM_registerMenuCommand('아카라이브 글쓰기 창 스크립트 토글', () => {
+                    if (GM_getValue('useDragdropUpload', true)) {
+                        GM_setValue('useDragdropUpload', false);
+                        toastmix.fire({
+                            icon: 'error',
+                            title: `아카 글쓰기 창 스크립트 비활성화
+                      다음번 작성시부터 적용됩니다`,
+                        });
+                    } else {
+                        GM_setValue('useDragdropUpload', true);
+                        toastmix.fire({
+                            icon: 'success',
+                            title: `아카 글쓰기 창 스크립트 활성화
+                      다음번 작성시부터 적용됩니다`,
+                        });
+                    }
+                });
             }
         } catch (err) {
             console.log(err);
@@ -1015,7 +1013,7 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
             let response, contentType, reader;
             const Referer = `${location.protocol}//${location.hostname}`;
             if (isArca) {
-                response = await fetch(url.replace('ac.namu.la', 'ac-o.namu.la'));
+                response = await fetch(url);
                 contentType = response.headers.get('content-type');
                 reader = response.body.getReader();
             } else if (useTampermonkey) {
@@ -1122,7 +1120,7 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
 
         console.time('modal open');
         console.time('fetch');
-        const metadata = await fetchAndDecode(url);
+        const metadata = await fetchAndDecode(url.replace(/ac-p\d.namu.la/g, 'ac-o.namu.la'));
         console.timeEnd('fetch');
         console.log(metadata);
 

--- a/AI_Image_EXIF_Viewer.user.js
+++ b/AI_Image_EXIF_Viewer.user.js
@@ -1122,7 +1122,7 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
 
         console.time('modal open');
         console.time('fetch');
-        const metadata = await fetchAndDecode(url.replace(/.+\.namu\.la/g, 'ac-o.namu.la'));
+        const metadata = await fetchAndDecode(url.replace(/ac.*\.namu\.la/g, 'ac-o.namu.la'));
         console.timeEnd('fetch');
         console.log(metadata);
 

--- a/AI_Image_EXIF_Viewer.user.js
+++ b/AI_Image_EXIF_Viewer.user.js
@@ -211,23 +211,25 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
                         });
                     }
                 });
-                GM_registerMenuCommand('아카라이브 EXIF 보존 토글', () => {
-                    if (GM_getValue('saveExifDefault', true)) {
-                        GM_setValue('saveExifDefault', false);
-                        toastmix.fire({
-                            icon: 'error',
-                            title: `아카라이브 EXIF 보존 비활성화
-                      다음번 작성시부터 버려집니다`,
-                        });
-                    } else {
-                        GM_setValue('saveExifDefault', true);
-                        toastmix.fire({
-                            icon: 'success',
-                            title: `아카라이브 EXIF 보존 활성화
-                      다음번 작성시부터 보존됩니다`,
-                        });
-                    }
-                });
+                // https://arca.live/b/aiart/121872652 ::::: 수정 250211
+                // todo: 일단 주석처리해보고 문제 없으면 그대로 두기
+                // GM_registerMenuCommand('아카라이브 글쓰기 창 스크립트 토글', () => {
+                //     if (GM_getValue('useDragdropUpload', true)) {
+                //         GM_setValue('useDragdropUpload', false);
+                //         toastmix.fire({
+                //             icon: 'error',
+                //             title: `아카 글쓰기 창 스크립트 비활성화
+                //       다음번 작성시부터 적용됩니다`,
+                //         });
+                //     } else {
+                //         GM_setValue('useDragdropUpload', true);
+                //         toastmix.fire({
+                //             icon: 'success',
+                //             title: `아카 글쓰기 창 스크립트 활성화
+                //       다음번 작성시부터 적용됩니다`,
+                //         });
+                //     }
+                // });
                 GM_registerMenuCommand('아카라이브 글쓰기 창 스크립트 토글', () => {
                     if (GM_getValue('useDragdropUpload', true)) {
                         GM_setValue('useDragdropUpload', false);
@@ -1120,7 +1122,7 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
 
         console.time('modal open');
         console.time('fetch');
-        const metadata = await fetchAndDecode(url.replace(/ac-p\d.namu.la/g, 'ac-o.namu.la'));
+        const metadata = await fetchAndDecode(url.replace(/.+\.namu\.la/g, 'ac-o.namu.la'));
         console.timeEnd('fetch');
         console.log(metadata);
 

--- a/AI_Image_EXIF_Viewer.user.js
+++ b/AI_Image_EXIF_Viewer.user.js
@@ -1122,7 +1122,7 @@ const footerString = `<div class="version">v${GM_info.script.version}  -  <a hre
 
         console.time('modal open');
         console.time('fetch');
-        const metadata = await fetchAndDecode(url.replace(/ac.*\.namu\.la/g, 'ac-o.namu.la'));
+        const metadata = await fetchAndDecode(url.replace(/ac.*\.namu\.la/g, 'ac-p3.namu.la'));
         console.timeEnd('fetch');
         console.log(metadata);
 


### PR DESCRIPTION
```js
// 1096L
const stealthData = await getStealthExif(url);
```

어느 순간부터 아카라이브 프록시 서버 p3가 추가되면서 예전 아카라이브 프록시 이미지 서버에 CORS 제한이 걸렸습니다. 이 때문에 원본 이미지 링크 (아마 ac-p2 서브도메인 이미지들)를 그대로 `getStealthExif` (1096L) 함수에 넣으면 에러가 납니다.

최신 프록시 서버로 우회하도록 변경하여 버그를 해결합니다.